### PR TITLE
Teach lexer to match token regexes over multiple lines

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -23,6 +23,26 @@
         "e1839a8": {
             "editable": true,
             "path": "."
+        },
+        "regex": {
+            "hashes": [
+                "sha256:22d7ef8c2df344328a8a3c61edade2ee714e5de9360911d22a9213931c769faa",
+                "sha256:3a699780c6b712c67dc23207b129ccc6a7e1270233f7aadead3ea3f83c893702",
+                "sha256:42f460d349baebd5faec02a0c920988fb0300b24baf898d9c139886565b66b6c",
+                "sha256:43bf3d79940cbdf19adda838d8b26b28b47bec793cda46590b5b25703742f440",
+                "sha256:47d6c7f0588ef33464e00023067c4e7cce68e0d6a686a73c7ee15abfdad503d4",
+                "sha256:5b879f59f25ed9b91bc8693a9a994014b431f224f492519ad0255ce6b54b83e5",
+                "sha256:8ba0093c412900f636b0f826c597a0c3ea0e395344bc99894ddefe88b76c9c7e",
+                "sha256:a4789254a1a0bd7a637036cce0b7ed72d8cc864e93f2e9cfd10ac00ae27bb7b0",
+                "sha256:b73cea07117dca888b0c3671770b501bef19aac9c45c8ffdb5bea2cca2377b0a",
+                "sha256:d3eb59fa3e5b5438438ec97acd9dc86f077428e020b015b43987e35bea68ef4c",
+                "sha256:d51d232b4e2f106deaf286001f563947fee255bc5bd209a696f027e15cf0a1e7",
+                "sha256:d59b03131a8e35061b47a8f186324a95eaf30d5f6ee9cc0637e7b87d29c7c9b5",
+                "sha256:dd705df1b47470388fc4630e4df3cbbe7677e2ab80092a1c660cae630a307b2d",
+                "sha256:e87fffa437a4b00afb17af785da9b01618425d6cd984c677639deb937037d8f2",
+                "sha256:ed40e0474ab5ab228a8d133759d451b31d3ccdebaff698646e54aff82c3de4f8"
+            ],
+            "version": "==2018.8.29"
         }
     },
     "develop": {

--- a/jeff65/blum/image.py
+++ b/jeff65/blum/image.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import re
+import regex as re
 import struct
 from . import symbol, types
 

--- a/jeff65/gold/grammar.py
+++ b/jeff65/gold/grammar.py
@@ -209,6 +209,8 @@ lex = Lexer(T.EOF, [
 
     # If we fail to match anything, consume one character, and move on.
     (r'(?s).', T.MYSTERY),
+    (Mode.STRING, r'(?s).', T.MYSTERY),
+    (Mode.COMMENT, r'(?s).', T.MYSTERY, ReStream.CHANNEL_HIDDEN),
 ])
 
 

--- a/jeff65/gold/grammar.py
+++ b/jeff65/gold/grammar.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import enum
-import re
+import regex as re
 from ..parsing import Grammar, Lexer, Parser, ReStream, Rule
 
 
@@ -161,27 +161,19 @@ lex = Lexer(T.EOF, [
     (Mode.COMMENT, re.escape('/*'), T.COMMENT_OPEN, ReStream.CHANNEL_HIDDEN),
     (Mode.COMMENT, re.escape('*/'), T.COMMENT_CLOSE, ReStream.CHANNEL_HIDDEN),
 
-    # This is necessary because the next pattern matches up to, but not
-    # including, the newline; however, it will happily match zero characters,
-    # causing an infinite loop. This matches that last newline.
-    (Mode.COMMENT, r'\n', T.COMMENT_TEXT, ReStream.CHANNEL_HIDDEN),
-
-    # Matches either to the next comment-control token, or the end of the line,
-    # whichever happens first.
-    (Mode.COMMENT, r'.*?(?=\/\*|\*\/|$)', T.COMMENT_TEXT,
+    # Matches up to the next comment-control token.
+    (Mode.COMMENT, r'(?s).*?(?=\/\*|\*\/)', T.COMMENT_TEXT,
      ReStream.CHANNEL_HIDDEN),
 
     # String delimiter. When the lexer comes back, it will be in string mode
     (re.escape('"'), T.STRING_DELIM),
 
     # String control tokens
-    (Mode.STRING, r'\\.', T.STRING_ESCAPE),
+    (Mode.STRING, r'(?s)\\.', T.STRING_ESCAPE),
     (Mode.STRING, re.escape('"'), T.STRING_DELIM),
 
-    # Matches non-special text inside a string. The newline-matching pattern is
-    # for the same reason as for comments.
-    (Mode.STRING, r'\n', T.STRING),
-    (Mode.STRING, r'.*?(?=\\|"|$)', T.STRING),
+    # Matches non-special text inside a string.
+    (Mode.STRING, r'(?s).*?(?=\\|")', T.STRING),
 
     # operators & punctuation. These must be ordered such that if A is a prefix
     # of B, then B comes before A. The easiest way to do this is to order them
@@ -216,7 +208,7 @@ lex = Lexer(T.EOF, [
     (re.escape('}'), T.BRACE_CLOSE),
 
     # If we fail to match anything, consume one character, and move on.
-    (r'.', T.MYSTERY),
+    (r'(?s).', T.MYSTERY),
 ])
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
 packages = find:
 install_requires =
   attrs>=18.1.0
+  regex>=2018.08.29
 python_requires = >=3.6
 
 [flake8]


### PR DESCRIPTION
- Switch from the builtin "re" module to the "regex" package
- Teach ReStream load the next section of the file automatically if it might allow a longer match.
- Tweak the gold-syntax lexer definition to take advantage of multiline token matches. This also required the addition of catchall token patterns to the string and comment modes.