### PR TITLE
Replace hardcoded pass sequence with a scheduler

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -201,6 +201,17 @@ coverage = ">=4.4"
 pytest = ">=3.6"
 
 [[package]]
+category = "dev"
+description = "pytest plugin for repeating tests"
+name = "pytest-repeat"
+optional = false
+python-versions = "*"
+version = "0.7.0"
+
+[package.dependencies]
+pytest = ">=2.8.7"
+
+[[package]]
 category = "main"
 description = "Alternative regular expression module, to replace re."
 name = "regex"
@@ -233,7 +244,7 @@ python-versions = "*"
 version = "0.2.9"
 
 [metadata]
-content-hash = "fb46675fefdeffe324484512a17b9911028e530bc52e73b420d97047fd5c2b78"
+content-hash = "e303f0e157e410cf7b716605edb015ae436b4dd15498d2bb3627095c20e765e0"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -255,6 +266,7 @@ pycodestyle = ["95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56
 pyflakes = ["5e8c00e30c464c99e0b501dc160b13a14af7f27d4dffb529c556e30a159e231d", "f277f9ca3e55de669fba45b7393a1449009cff5a37d1af10ebb76c52765269cd"]
 pytest = ["65aeaa77ae87c7fc95de56285282546cfa9c886dc8e5dc78313db1c25e21bc07", "6ac6d467d9f053e95aaacd79f831dbecfe730f419c6c7022cb316b365cd9199d"]
 pytest-cov = ["0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33", "230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"]
+pytest-repeat = ["637e68dd615e850b47b2dee0edf72bcede44de6a5335837fe2980daaf0cdab2b", "c51e166d652cf779588801f8b57594a46e62f05877d3929b10aadb874a9faf04"]
 regex = ["03a42220f638f5b6e80f688645bb1e8598e074df16a33106126d3ccbe4c01bfd", "0be9a895dab15b1d31505680bf0fe2f717f602edeeeb46f87c44878c7910ece5", "1afef5d9ba1f29b369b4133571f2190bd918e3b7d572df0b922168aec209bbda", "33f8fa1561110cafcab93a53d37c77508e8ba8addf8b2a6ac31e4b2c1afa631b", "54ff106533b222eb0201f48cdeaa587e9e03a8767901e60bd6288239970d2b55", "b4d13198acfac8b96abeb72224075f4a043db203214d27c6309b1a778f2304ac", "c645a577c7b56fd592cff9b05e513bc077740f338d3e64d1364390ffc2a536d7", "e7a957eac79ec9318199f67bf7d041c3c55f2e8b780c68b2403bd29d1863d6d7", "f5707f7f30994e2b0bf9c62db43f8a8d04b940de89685c644deeb93733cafd7a"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
 toml = ["229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c", "235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e", "f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ regex = ">=2018.08.29"
 [tool.poetry.dev-dependencies]
 pytest = ">=4.2"
 pytest-cov = ">=2.6.1"
+pytest-repeat = "^0.7.0"
 flake8 = "^3.7.4"
 coverage = "^4.5.2"
 hypothesis = "^4.5.0"

--- a/src/jeff65/__init__.py
+++ b/src/jeff65/__init__.py
@@ -44,15 +44,13 @@ class BraceMessage:
 BraceMessage.install()
 
 
+debugopts = {"log_debug": False, "unstable_pass_schedule": False}
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser()
-
     parser.add_argument(
-        "--debug",
-        help="run in debug mode",
-        dest="debug",
-        action="store_true",
-        default=False,
+        "-Z", help="enable debug settings", dest="debugopt", action="append"
     )
     parser.add_argument(
         "-v",
@@ -80,7 +78,18 @@ def main(argv=None):
     objdump_parser.set_defaults(func=cmd_objdump)
 
     args = parser.parse_args(argv)
-    if args.debug:
+    if args.debugopt is not None:
+        unknown_opts = set(args.debugopt) - debugopts.keys()
+        if len(unknown_opts) > 0:
+            optlist = ", ".join(unknown_opts)
+            print(f"Unknown debugging options {optlist}", file=sys.stderr)
+            print(f"Allowed options are:", file=sys.stderr)
+            for opt in sorted(debugopts.keys()):
+                print(f"    {opt}", file=sys.stderr)
+            sys.exit(1)
+        debugopts.update({opt: True for opt in args.debugopt})
+
+    if debugopts["log_debug"]:
         logging.basicConfig(level=logging.DEBUG)
     elif args.verbose:
         logging.basicConfig(level=logging.INFO)

--- a/src/jeff65/ast.py
+++ b/src/jeff65/ast.py
@@ -119,6 +119,21 @@ class AstNode:
         return current
 
 
+class NullPass:
+    """Base class for null passes.
+
+    Inserting null passes is helpful when writing annotations for the
+    scheduler; in particular, it allows a set of tags to be reduced to a single
+    tag.
+    """
+
+    def transform_enter(self, t, node):
+        return node
+
+    def transform_exit(self, t, node):
+        return node
+
+
 class TranslationPass:
     """Base class for translation passes."""
 

--- a/src/jeff65/gold/compiler.py
+++ b/src/jeff65/gold/compiler.py
@@ -17,7 +17,7 @@
 import logging
 import sys
 from . import grammar
-from .. import ast, blum, parsing
+from .. import ast, blum, parsing, scheduler
 from .passes import asm, binding, lower, resolve, simplify, typepasses
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ def parse(fileobj, name):
 def translate(unit):
     # parse will close the file for us
     obj = parse(open_unit(unit), name=unit.name)
-    for p in passes:
+    for p in scheduler.create_schedule(passes):
         obj = obj.transform(p())
         logger.debug(__("Pass {}:\n{:p}", p.__name__, obj))
 

--- a/src/jeff65/gold/passes/asm.py
+++ b/src/jeff65/gold/passes/asm.py
@@ -30,6 +30,10 @@ def asmrun(fmt, *args):
 
 @pattern.transform(pattern.Order.Any)
 class AssembleWithRelocations:
+    introduces = {"asmrun"}
+    uses = set()
+    deletes = {"lda", "jmp", "rts", "sta"}
+
     @pattern.match(
         ast.AstNode(
             "lda",
@@ -74,6 +78,10 @@ class AssembleWithRelocations:
 
 @pattern.transform(pattern.Order.Ascending)
 class FlattenSymbol:
+    introduces = {"fun_symbol"}
+    uses = set()
+    deletes = {"fun", "asmrun"}
+
     @pattern.match(
         ast.AstNode(
             "block",

--- a/src/jeff65/gold/passes/binding.py
+++ b/src/jeff65/gold/passes/binding.py
@@ -87,6 +87,10 @@ class ShadowNames(ScopedPass):
     constructing types.
     """
 
+    introduces = {"binding:shadows"}
+    uses = set()
+    deletes = set()
+
     def exit_constant(self, node):
         self.bind_name(node.attrs["name"], True)
         return node
@@ -95,12 +99,20 @@ class ShadowNames(ScopedPass):
 class BindNamesToTypes(ScopedPass):
     """Binds names to types. These are later overridden by the storage."""
 
+    introduces = {"binding:types"}
+    uses = {"constant", "binding:typenames"}
+    deletes = set()
+
     def exit_constant(self, node):
         self.bind_name(node.attrs["name"], node.attrs["type"])
         return node
 
 
 class EvaluateConstants(ScopedPass):
+    introduces = {"binding:constants"}
+    uses = {"resolved:functions"}
+    deletes = {"constant"}
+
     def __init__(self):
         super().__init__()
         self.evaluating = False
@@ -125,6 +137,10 @@ class EvaluateConstants(ScopedPass):
 
 
 class ResolveConstants(ScopedPass):
+    introduces = {"resolved:constants"}
+    uses = {"binding:constants", "binding:types"}
+    deletes = set()
+
     def exit_identifier(self, node):
         value = self.look_up_constant(node.attrs["name"])
         if not value:

--- a/src/jeff65/gold/passes/lower.py
+++ b/src/jeff65/gold/passes/lower.py
@@ -21,6 +21,10 @@ from ...pattern import Predicate as P
 
 @pattern.transform(pattern.Order.Any)
 class LowerAssignment:
+    introduces = {"lda"}
+    uses = {"binding:types", "resolved:storage"}
+    deletes = {"set"}
+
     @pattern.match(
         ast.AstNode(
             "block",
@@ -47,6 +51,10 @@ class LowerAssignment:
 
 
 class LowerFunctions(ast.TranslationPass):
+    introduces = {"rts"}
+    uses = {"fun"}
+    deletes = set()
+
     def exit_fun(self, node):
         children = node.select("body", "stmt")
         children.append(asm.rts(node.span))

--- a/src/jeff65/gold/passes/resolve.py
+++ b/src/jeff65/gold/passes/resolve.py
@@ -22,6 +22,10 @@ from ...pattern import Predicate as P
 
 @pattern.transform(pattern.Order.Descending)
 class ResolveStorage:
+    introduces = {"resolved:storage", "absolute_storage", "immediate_storage"}
+    uses = {"resolved:constants", "binding:types"}
+    deletes = {"deref", "numeric"}
+
     @pattern.match(
         ast.AstNode(
             "deref",
@@ -48,6 +52,10 @@ class ResolveStorage:
 class ResolveUnits(binding.ScopedPass):
     """Resolves external units identified in 'use' statements."""
 
+    introduces = {"binding:unit"}
+    uses = set()
+    deletes = {"use"}
+
     builtin_units = {"mem": mem.MemUnit()}
 
     def exit_use(self, node):
@@ -64,6 +72,10 @@ class ResolveUnits(binding.ScopedPass):
 
 class ResolveMembers(binding.ScopedPass):
     """Resolves members to functions."""
+
+    introduces = {"resolved:functions"}
+    uses = {"binding:unit"}
+    deletes = {"member_access"}
 
     def exit_member_access(self, node):
         member = node.attrs["member"]

--- a/src/jeff65/gold/passes/typepasses.py
+++ b/src/jeff65/gold/passes/typepasses.py
@@ -20,6 +20,10 @@ from ...blum import types
 
 
 class ConstructTypes(ast.TranslationPass):
+    introduces = {"binding:typenames"}
+    uses = set()
+    deletes = {"ref"}
+
     builtin_types = {
         "u8": types.u8,
         "u16": types.u16,
@@ -42,6 +46,10 @@ class ConstructTypes(ast.TranslationPass):
 
 
 class PropagateTypes(binding.ScopedPass):
+    introduces = {"binding:types"}
+    uses = {"binding:constants", "binding:typenames"}
+    deletes = set()
+
     def enter_identifier(self, node):
         t = self.look_up_name(node.attrs["name"])
         return node.update_attrs({"type": t})

--- a/src/jeff65/graph.py
+++ b/src/jeff65/graph.py
@@ -1,0 +1,102 @@
+# jeff65 graph manipulation
+# Copyright (C) 2019  jeff65 maintainers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import attr
+import random
+
+
+class TopologyError(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
+@attr.s(slots=True, cmp=False)
+class Node:
+    # N.B. we use a list of links to guarantee stable order; a set would result
+    # in different output each run.
+    value = attr.ib()
+    links = attr.ib(factory=list, converter=list)
+
+
+class Graph:
+    def __init__(self, nodes=None, stable=True):
+        # Keep track of order; by traversing nodes in a consistent order, we
+        # can ensure consistent output (if we need to).
+
+        self._nodelist = [] if nodes is None else list(nodes)
+        self._nodes = set(self._nodelist)
+        self._stable = stable
+        self._sorted = None
+
+    @property
+    def nodes(self):
+        return set(self._nodes)
+
+    def __iter__(self):
+        return iter(self._nodelist)
+
+    def add_node(self, node):
+        if node not in self.nodes:
+            self._nodelist.append(node)
+            self._nodes.add(node)
+        for n in node.links:
+            self.add_node(n)
+
+    def add_edge(self, start, end):
+        if start not in self._nodes:
+            raise TopologyError("start node not in graph")
+        if end not in self._nodes:
+            raise TopologyError("end node not in graph")
+        start.links.append(end)
+        self._sorted = None
+
+    def _sort(self):
+        # DFS topological sort per Tarjan (1976). All nodes start out in the
+        # white set. We perform a recursive DFS, marking nodes grey on the way
+        # down and black on the way up, emitting them as we mark them black.
+
+        # If we end up having to work with graphs so big that we end up blowing
+        # out the stack, consider switching to the Kahn (1962) algorithm, which
+        # is non-recursive, but more irritating to implement as it requires
+        # making a copy of the graph to modify destructively.
+
+        white = list(self._nodelist)
+        if not self._stable:
+            random.shuffle(white)
+
+        black = set()
+        grey = set()
+
+        def darken(n):
+            if n in black:
+                return
+            if n in grey:
+                raise TopologyError("Not a DAG")
+
+            grey.add(n)
+            for m in n.links:
+                yield from darken(m)
+            grey.remove(n)
+            black.add(n)
+            yield n
+
+        while len(white) > 0:
+            yield from darken(white.pop())
+
+    def sorted(self):
+        if self._sorted is None:
+            self._sorted = list(self._sort())
+        return self._sorted

--- a/src/jeff65/scheduler.py
+++ b/src/jeff65/scheduler.py
@@ -1,0 +1,56 @@
+# jeff65 pass scheduler
+# Copyright (C) 2019  jeff65 maintainers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Automatic pass scheduler
+
+Each pass is annotated with a list of tags it introduces, uses, and deletes.
+Tags should include AST node names and metadata introduced. Even if the pass
+does not delete all instances of an AST node, it should still list it as
+deleted.
+
+Passes are ordered such that all introductions of a node precede all uses and
+deletions of it, and all uses precede all deletions.
+"""
+
+import collections.abc
+import jeff65
+from .graph import Graph, Node
+
+
+def create_schedule(passes):
+    g = Graph(
+        (Node(p) for p in passes), stable=jeff65.debugopts["unstable_pass_schedule"]
+    )
+    assert all(
+        isinstance(n.value.introduces, collections.abc.Set)
+        and isinstance(n.value.uses, collections.abc.Set)
+        and isinstance(n.value.deletes, collections.abc.Set)
+        for n in g
+    )
+    for nf in g:
+        for n0 in g:
+            if n0 is not nf and _depends(n0.value, nf.value):
+                g.add_edge(nf, n0)
+    return [n.value for n in g.sorted()]
+
+
+def _depends(p0, pf):
+    """Tests whether pf depends on p0."""
+    return (
+        any(p0.introduces & pf.uses)
+        or any(p0.introduces & pf.deletes)
+        or any(p0.uses & pf.deletes)
+    )


### PR DESCRIPTION
Passes are now tagged with information about what they do, and are automatically placed into the correct order. The scheduling algorithm is designed such that the same input will always produce the same output, so that the order that passes tests is the same order used in production. This can be disabled for testing purposes.